### PR TITLE
Refactor Home View and Automatically Animate Deals Page View.Ⓜ️

### DIFF
--- a/lib/core/utils/widgets/bottom_nav_bar.dart
+++ b/lib/core/utils/widgets/bottom_nav_bar.dart
@@ -1,6 +1,7 @@
 // ignore_for_file: library_private_types_in_public_api
 
 import 'package:e_commerce_app/core/utils/theming/app_colors.dart';
+import 'package:e_commerce_app/features/home/views/home_view.dart';
 import 'package:flutter/material.dart';
 
 class BottomNavBar extends StatefulWidget {
@@ -14,9 +15,7 @@ class _BottomNavBarState extends State<BottomNavBar> {
   int selectedIndex = 0;
 
   static final List<Widget> appPages = <Widget>[
-    const Scaffold(
-      backgroundColor: Colors.amberAccent,
-    ),
+    const HomeView(),
     const Scaffold(
       backgroundColor: Colors.red,
     ),
@@ -54,7 +53,7 @@ class _BottomNavBarState extends State<BottomNavBar> {
             label: 'Browse',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.favorite_outlined),
+            icon: Icon(Icons.favorite_outline),
             label: 'Favorites',
           ),
           BottomNavigationBarItem(
@@ -62,7 +61,7 @@ class _BottomNavBarState extends State<BottomNavBar> {
             label: 'Cart',
           ),
           BottomNavigationBarItem(
-            icon: Icon(Icons.person_outlined),
+            icon: Icon(Icons.person_outline),
             label: 'Profile',
           ),
         ],

--- a/lib/features/home/views/widgets/deals_section_page_veiw.dart
+++ b/lib/features/home/views/widgets/deals_section_page_veiw.dart
@@ -1,0 +1,31 @@
+import 'package:e_commerce_app/core/utils/models/product_model.dart';
+import 'package:e_commerce_app/features/home/views/widgets/deals_section_card.dart';
+import 'package:expandable_page_view/expandable_page_view.dart';
+import 'package:flutter/material.dart';
+
+class DealsSectionPageView extends StatelessWidget {
+  const DealsSectionPageView({
+    super.key,
+    required PageController pageController,
+    required this.products,
+  }) : _pageController = pageController;
+
+  final PageController _pageController;
+  final List<ProductModel> products;
+
+  @override
+  Widget build(BuildContext context) {
+    return ExpandablePageView.builder(
+      controller: _pageController,
+      allowImplicitScrolling: true,
+      animateFirstPage: true,
+      scrollDirection: Axis.horizontal,
+      itemCount: products.length,
+      itemBuilder: (context, index) {
+        return DealsSectionCard(
+          product: products[index],
+        );
+      },
+    );
+  }
+}

--- a/lib/features/home/views/widgets/home_view_deals_section.dart
+++ b/lib/features/home/views/widgets/home_view_deals_section.dart
@@ -1,9 +1,10 @@
+import 'dart:async';
+
 import 'package:e_commerce_app/core/utils/helpers/spacing.dart';
 import 'package:e_commerce_app/core/utils/models/product_model.dart';
-import 'package:e_commerce_app/features/home/views/widgets/deals_section_card.dart';
 import 'package:e_commerce_app/features/home/views/widgets/deals_section_card_indicators_row.dart';
 import 'package:e_commerce_app/features/home/views/widgets/deals_section_header.dart';
-import 'package:expandable_page_view/expandable_page_view.dart';
+import 'package:e_commerce_app/features/home/views/widgets/deals_section_page_veiw.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/widgets.dart';
 
@@ -60,6 +61,24 @@ class _HomeViewDealsSectionState extends State<HomeViewDealsSection> {
         activeIndex = _pageController.page!.round();
       });
     });
+
+    // Start the animation
+    _animatePageView();
+  }
+
+  void _animatePageView() {
+    Timer.periodic(const Duration(seconds: 5), (Timer timer) {
+      if (activeIndex < widget.products.length - 1) {
+        activeIndex++;
+      } else {
+        activeIndex = 0;
+      }
+      _pageController.animateToPage(
+        activeIndex,
+        duration: const Duration(milliseconds: 400),
+        curve: Curves.easeIn,
+      );
+    });
   }
 
   @override
@@ -67,18 +86,8 @@ class _HomeViewDealsSectionState extends State<HomeViewDealsSection> {
     return Column(
       children: [
         const DealsSectionHeader(),
-        ExpandablePageView.builder(
-          controller: _pageController,
-          allowImplicitScrolling: true,
-          animateFirstPage: true,
-          scrollDirection: Axis.horizontal,
-          itemCount: widget.products.length,
-          itemBuilder: (context, index) {
-            return DealsSectionCard(
-              product: widget.products[index],
-            );
-          },
-        ),
+        DealsSectionPageView(
+            pageController: _pageController, products: widget.products),
         verticalSpace(6),
         DealsSectionCardIndicatorsRow(
           activeIndex: activeIndex,


### PR DESCRIPTION
- Extract deals section page view logic into a separate widget
- Implement automatic `DealsSectionPageView` animation for deals section
- Replace placeholder with `HomeView` in bottom navigation
- Update `BottomNavBar` icons to use outline variants