### PR TITLE
Refactor Image Display In Favorite Screen.Ⓜ️

### DIFF
--- a/lib/e_commerce_app.dart
+++ b/lib/e_commerce_app.dart
@@ -11,7 +11,7 @@ class EcommerceApp extends StatelessWidget {
     return MaterialApp(
       debugShowCheckedModeBanner: false,
       initialRoute:
-          appRouter.isFirstTime ? AppRoutes.onBoarding : AppRoutes.home,
+          appRouter.isFirstTime ? AppRoutes.onBoarding : AppRoutes.favorite,
       onGenerateRoute: appRouter.onGenerateRoute,
     );
   }

--- a/lib/features/favorite/view/widgets/list_tile_product_image.dart
+++ b/lib/features/favorite/view/widgets/list_tile_product_image.dart
@@ -15,13 +15,13 @@ class ListTileProductImage extends StatelessWidget {
       aspectRatio: 0.9,
       child: Container(
         margin: const EdgeInsets.all(7.0),
-        padding: const EdgeInsets.all(2),
         decoration: BoxDecoration(
           color: AppColors.backgroundSecondary,
           borderRadius: BorderRadius.circular(24),
-        ),
-        child: Image.asset(
-          productImage,
+          image: DecorationImage(
+            image: AssetImage(productImage),
+            fit: BoxFit.fill,
+          ),
         ),
       ),
     );


### PR DESCRIPTION
Updates the ListTileProductImage widget to use a DecorationImage with BoxFit.fill to ensure that product images are displayed correctly and fill their containers. The padding has been removed because in this case it is no need for it.

**Favorite Screen Preview**
![Screenshot_1713534275](https://github.com/MarioOsama/e_commerce_app/assets/114400410/f73b2db9-666a-4882-b5ca-2b4de72a7b0e)
